### PR TITLE
Fix second toolbar and fame/tax UX

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ If you just comment on Steam, I may not notice (I'm not even logged in most of t
 **Original Mod:** [New Game+](https://steamcommunity.com/sharedfiles/filedetails/?id=3373526993)
 
 - **EN:** This is a revival and feature extension of the above mod. Unsubscribe from the original when switching to this version.
-- **JP:** このmodは上記のmodを復活して機能を追加して更新しました。本バージョンをサブスク登録した際に元バージョンのサブスクを解除してください。
+- **JP:** この mod は上記の mod を復活して機能を追加して更新しました。本バージョンをサブスク登録した際に元バージョンのサブスクを解除してください。
 - **CN:** 这是上述模组的复兴和功能扩展版本。切换到本版本时，请取消订阅原模组。
 
 Credits again to the original author for creating the original mod. This mod has changed quite significantly, so I don't think anyone minds me publishing a fork.
@@ -54,7 +54,7 @@ Credits again to the original author for creating the original mod. This mod has
 - Include Skills
 - Include Faith
 - Include Karma
-- Include Fame
+- Include Fame (note: tax is based on fame; importing fame will make your first tax bill high)
 - Include Craft Recipes
 - Cure Ether Diseases
 - Cure Mutations

--- a/package.xml
+++ b/package.xml
@@ -70,7 +70,7 @@
     [*]Include Skills
     [*]Include Faith
     [*]Include Karma
-    [*]Include Fame
+    [*]Includes your fame (Warning: your tax will start high)
     [*]Include Craft Recipes
     [*]Cure Ether Diseases
     [*]Cure Mutations

--- a/src/Export/CharacterExporter.cs
+++ b/src/Export/CharacterExporter.cs
@@ -32,6 +32,11 @@ public static class CharacterExporter
 	public static ItemExportResult ExportAllItems(Chara c)
 	{
 		ItemExportResult result = new ItemExportResult();
+		for (int i = 0; i < ItemSlotManager.ToolbarSlotCount; i++)
+		{
+			result.toolbarItems.Add(null);
+		}
+
 		Card charaCard = (Card)c;
 
 		// Step 1: Build equipped item map from body.slots
@@ -103,7 +108,9 @@ public static class CharacterExporter
 					break;
 
 				case ItemLocation.Toolbar:
-					result.toolbarItems.Add(thingData);
+					int slot = t.invX;
+					if (slot >= 0 && slot < ItemSlotManager.ToolbarSlotCount)
+						result.toolbarItems[slot] = thingData;
 					break;
 
 				case ItemLocation.Toolbelt:

--- a/src/Import/CharacterImporter.cs
+++ b/src/Import/CharacterImporter.cs
@@ -470,14 +470,17 @@ public static class CharacterImporter
 			}
 		}
 
-		// 1. Toolbar items (if importIncludeToolbar enabled)
-		if (ModConfig.GetOption("includeToolbar")?.Value == true && dumpData.toolbarItems != null && dumpData.toolbarItems.Count > 0)
+		// 1. Toolbar items (if importIncludeToolbar enabled). Empty slots null
+		if (ModConfig.GetOption("includeToolbar")?.Value == true && dumpData.toolbarItems != null)
 		{
-			for (int i = 0; i < dumpData.toolbarItems.Count && i < ItemSlotManager.ToolbarSlotCount; i++)
+			int n = System.Math.Min(dumpData.toolbarItems.Count, ItemSlotManager.ToolbarSlotCount);
+			for (int i = 0; i < n; i++)
 			{
+				ThingData item = dumpData.toolbarItems[i];
+				if (item == null) continue;
 				try
 				{
-					StorageFixed.SpawnToToolbar(c, dumpData.toolbarItems[i], i);
+					StorageFixed.SpawnToToolbar(c, item, i);
 				}
 				catch (System.Exception)
 				{

--- a/src/ModLocalization.cs
+++ b/src/ModLocalization.cs
@@ -348,15 +348,15 @@ public static class ModLocalization
 			TooltipKey = "ImportIncludeFameTooltip",
 			LabelTranslations = new Dictionary<string, string>
 			{
-				{ "EN", "Include Fame" },
-				{ "JP", "名声を含める" },
-				{ "CN", "包含声望" }
+				{ "EN", "Includes your fame (Warning: your tax will start high)" },
+				{ "JP", "名声を含める（注意：税が高く始まります）" },
+				{ "CN", "包含声望（注意：税款会从较高开始）" }
 			},
 			TooltipTranslations = new Dictionary<string, string>
 			{
-				{ "EN", "Includes your fame" },
-				{ "JP", "あなたの名声を含めます" },
-				{ "CN", "包含您的声望" }
+				{ "EN", "Includes your fame. Tax is based on fame. Importing fame will make your first tax bill high." },
+				{ "JP", "あなたの名声を含めます。税は名声に基づくため、名声をインポートすると最初の税額が高くなります。" },
+				{ "CN", "包含您的声望。税基于声望。导入声望会使您的第一笔税款变高。" }
 			}
 		},
 		new UIOption

--- a/src/Tests/SlotTester.cs
+++ b/src/Tests/SlotTester.cs
@@ -20,7 +20,7 @@ public static class SlotTester
 			return;
 		}
 
-		// 1. Fill toolbar with 9 amber
+		// 1. Fill toolbar (both bars) with amber
 		for (int x = 0; x < ItemSlotManager.ToolbarSlotCount; x++)
 		{
 			Card card = (Card)ThingGen.Create("throw_putit");

--- a/src/Utils/ItemSlotManager.cs
+++ b/src/Utils/ItemSlotManager.cs
@@ -42,8 +42,8 @@ public static class ItemSlotManager
 		public const string AccessoryContainer = "toolbelt";  // The 5-slot container
 	}
 
-	// Slot counts
-	public const int ToolbarSlotCount = 9;
+	// Slot counts (game has 2 hotbar pages × 10 slots = 20)
+	public const int ToolbarSlotCount = 20;
 	public const int AccessorySlotCount = 5;
 	public const int PlayerInventoryMaxSlots = 35; // Player's main inventory has 35 slots (0-34)
 
@@ -305,8 +305,8 @@ public static class StorageAuto
 // Handles storage that requires explicit slot specification - strict bounds checking
 public static class StorageFixed
 {
-	// Insert item into toolbar at normalized slot (0-8)
-	// Throws ArgumentOutOfRangeException if slot >= 9
+	// Insert item into toolbar at normalized slot (0-19, both hotbar pages)
+	// Throws ArgumentOutOfRangeException if slot >= 20
 	// Returns the slot if successful, throws if failed
 	public static int InsertToToolbar(Chara c, Thing item, int normalizedSlot)
 	{
@@ -382,8 +382,8 @@ public static class StorageFixed
 		return slot.index;
 	}
 
-	// Spawn item to toolbar from ThingData descriptor at normalized slot (0-8)
-	// Throws ArgumentOutOfRangeException if slot >= 9
+	// Spawn item to toolbar from ThingData descriptor at normalized slot (0-19)
+	// Throws ArgumentOutOfRangeException if slot >= 20
 	// Returns the slot if successful, throws if failed
 	public static int SpawnToToolbar(Chara c, ThingData descriptor, int normalizedSlot)
 	{


### PR DESCRIPTION
## Addressed

- **Second toolbar:** Both hotbar pages will be exported.
- **Tax / fame:** Clarified that tax is fame-based. Added warning to the fame option: label “Includes your fame (Warning: your tax will start high)” and tooltip. README and package.xml updated.

## Not addressed (yet)

- **Influence on NPC zones:** Still does not carry over. No implementation yet; could be added later as a feature, until after I play the game enough to know what influence even means (oops I been spoilered).