### PR TITLE
Carry container settings and upgrades across NG+

### DIFF
--- a/NewGamePlus.csproj
+++ b/NewGamePlus.csproj
@@ -82,6 +82,10 @@
     <Reference Include="Plugins.UI">
       <HintPath>$(ELIN_INSTALL_PATH)\Elin_Data\Managed\Plugins.UI.dll</HintPath>
     </Reference>
+    <Reference Include="Newtonsoft.Json">
+      <HintPath>$(ELIN_INSTALL_PATH)\Elin_Data\Managed\Newtonsoft.Json.dll</HintPath>
+      <Private>False</Private>
+    </Reference>
     <Reference Include="UnityEngine">
       <HintPath>$(ELIN_INSTALL_PATH)\Elin_Data\Managed\UnityEngine.dll</HintPath>
     </Reference>

--- a/Properties/AssemblyInfo.cs
+++ b/Properties/AssemblyInfo.cs
@@ -13,5 +13,5 @@ using System.Runtime.Versioning;
 [assembly: AssemblyTrademark("")]
 [assembly: ComVisible(false)]
 [assembly: Guid("6613b7d5-5551-413f-af3d-0e5cffae4c3d")]
-[assembly: AssemblyFileVersion("1.3.0.0")]
-[assembly: AssemblyVersion("1.3.0.0")]
+[assembly: AssemblyFileVersion("1.3.3.0")]
+[assembly: AssemblyVersion("1.3.3.0")]

--- a/docs/Elin Systems Reference.md
+++ b/docs/Elin Systems Reference.md
@@ -43,23 +43,44 @@
 
 ### Card Storage Layout
 
-- **`Card._ints`** (int array) - Primary storage for card properties. Key indices:
-  - `[0]`: `_bits1` (packed bitfield — isOn, isHidden, isCrafted, etc.)
-  - `[1]`: `uid` (unique ID) for containers; spell/ability type ID for scrolls/whips
-  - `[2]`: `_bits2` (packed bitfield — noSell, isCopy, etc.)
+`BaseCard` declares three sparse dictionaries (`BaseCard.cs:6-13`): `mapObj`, `mapInt`, `mapStr`. `Card` adds the fixed-size `_ints[30]` array, the packed `_bits1` / `_bits2`, and the `sockets` list on top of those.
+
+- **`Card._ints`** (`int[30]`, declared on `Card`) - Fixed-size primary array. Used indices on `Card`:
+  - `[0]`: `_bits1` packed bitfield (isOn, isHidden, isCrafted, etc.)
+  - `[1]`: `uid` (unique ID); also stores spell/ability type ID for scrolls/whips
+  - `[2]`: `_bits2` packed bitfield (noSell, isCopy, etc.)
   - `[4]`: `idMaterial` (material ID)
+  - `[5]`: `dir` (rotation)
   - `[6]`: `Num` (stack quantity)
+  - `[7]`: `_x` (pos.x)
+  - `[8]`: **unused on `Card`**. Do not confuse with `mapInt[8]` = `c_containerSize`.
+  - `[9]`: `_z` (pos.z)
+  - `[10]`: `genLv`
   - `[14]`: `hp` (current hit points)
   - `[24]`: `feat` (unspent feat points)
   - `[25]`: `LV` (character level)
   - `[26]`: `exp` (experience points)
-- **`Card._bits1` / `Card._bits2`** - Packed bitfields unpacked from `_ints[0]` and `_ints[2]` during deserialization via `SetInt()`. Game never calls `ChangeMaterial` on load — it calls `_bits1.SetInt(_ints[0])` and `_bits2.SetInt(_ints[2])` directly.
-- **`Card.mapInt`** (Dictionary<int, int>) - Sparse property map for card-specific integers:
-  - Key 3: `c_dyeMat` (dye material)
-  - Key 7: `c_charges` (charges remaining)
-  - Key 27: `c_ammo` (ammo count)
-  - Other keys used for various card properties
-- **`Card.sockets`** (List<int>) - Weapon mod sockets for ranged weapons. Count = list length. Value: 0 = empty slot, otherwise `elementId * 1000 + encLv`.
+- **`Card._bits1` / `Card._bits2`** - Packed bitfields unpacked from `_ints[0]` and `_ints[2]` during deserialization via `SetInt()`. Game never calls `ChangeMaterial` on load. It calls `_bits1.SetInt(_ints[0])` and `_bits2.SetInt(_ints[2])` directly.
+- **`Card.mapInt`** (`Dictionary<int, int>`, sparse) - Property keys defined in `CINT.cs`. Common entries on containers:
+  - `3`: `c_dyeMat` (dye material)
+  - `7`: `c_charges` (charges remaining)
+  - `8`: `c_containerSize` (container grid: `width * 100 + height`; 0 means default 8x5)
+  - `15`: `c_indexContainerIcon` (icon variant)
+  - `21`: `c_priceFix` (price modifier; shop pricing)
+  - `27`: `c_ammo` (ammo count)
+  - `50`: `c_lockLv` (lock level)
+  - `129`: `isAmbushWarned` (added in EA 23.299; no `c_*` getter, accessed via `GetBool(129)` / `GetInt(129)`)
+- **`Card.mapObj`** (`Dictionary<int, object>`, sparse) - Boxed object keys defined in `COBJ.cs`. Common entries on containers:
+  - `2`: `c_windowSaveData` (`Window.SaveData`; per-container UI prefs; getter at `Card.cs:1848-1858`)
+  - `10`: `c_copyContainer` (`Thing` reference for deposit/copy boxes; getter at `Card.cs:1836-1846`)
+  - `12`: `c_containerUpgrade` (`ContainerUpgrade` with `cap` and `cool`; getter at `Card.cs:1908-1918`)
+  - The `c_containerUpgrade` getter lazy-creates a default `ContainerUpgrade` on read. The `c_windowSaveData` getter does NOT lazy-create (returns null if absent).
+- **`Card.mapStr`** (`Dictionary<int, string>`, sparse) - String keys defined in `CSTR.cs`. Common entries on containers:
+  - `1`: `c_altName` (player-renamed name)
+  - `2`: `c_altName2`
+  - `5`: `c_idRefCard` (chara reference ID stuffed in container, e.g. corpses)
+  - `12`: `c_extraNameRef` (extra name suffix)
+- **`Card.sockets`** (`List<int>`) - Weapon mod sockets for ranged weapons. Count = list length. Value: 0 = empty slot, otherwise `elementId * 1000 + encLv`.
 
 ### Chara Element Containers
 
@@ -410,6 +431,76 @@
   - If element 41 (ranged): assigns to `slotRange`
   - Does NOT trigger equip refresh or element modification — just adds the slot
 - **`CharaBody.RefreshBodyParts()`** - Rebuilds internal slot references (main hand, off hand, range) from the current `slots` list. Should be called after adding/removing body parts.
+
+## Inventory Containers
+
+### `ThingContainer`
+
+- **`Card.things`** (`ThingContainer`, inherits `List<Thing>`) - Container's children plus grid metadata. Constructed once per Card; grid dimensions exposed via `width`/`height` int fields.
+- **`ThingContainer.SetOwner(Card owner)`** at `ThingContainer.cs:69-79` - Sets `owner`, then `width = c_containerSize / 100`, `height = c_containerSize % 100`. If `width == 0`, defaults to 8x5. Called once during `Card.Create` (transitively from `ThingGen.Create`, when `c_containerSize` is still empty), and again in `Card._OnDeserialized` and in `Card.Duplicate` at `Card.cs:3559-3565` (the latter is guarded by `if (thing.c_containerSize != 0)`). Modifying `c_containerSize` later does NOT auto-resize the live container; `SetOwner` must be re-run.
+- **`ThingContainer.SetSize(int w, int h)`** at line 366 - Writes `owner.c_containerSize = w * 100 + h`, then re-runs `SetOwner(owner)` (which re-derives `width`/`height` from the new value). Use this when changing size at runtime. Does NOT call `RefreshGrid()`.
+- **`ThingContainer.ChangeSize(int w, int h)`** at lines 81-88 - Sets `width`/`height` directly, writes `c_containerSize = w * 100 + h`, then calls `RefreshGrid()`. Used when the visible grid layout must redraw.
+- **`ThingContainer.GridSize`** => `width * height` (line 48).
+- **`ThingContainer.IsMagicChest`** => `owner.trait is TraitMagicChest` (line 54).
+- **`ThingContainer.MaxCapacity`** at lines 57-67 - Returns `100 + owner.c_containerUpgrade.cap` for magic chests, else `GridSize`. Magic chests do not write `c_containerSize`; their capacity scales from the upgrade row instead.
+
+### `ContainerUpgrade`
+
+- **`ContainerUpgrade.cs`** - Two `[JsonProperty]` ints: `cap` (storage wrench bonus, +20 per stack) and `cool` (fridge wrench flag, 0 or 1). Stored in `mapObj[12]`.
+- **`TraitMagicChest.IsFridge`** at `TraitMagicChest.cs:23` => `owner.c_containerUpgrade.cool > 0`.
+- **`TraitMagicChest.OriginalElectricity`** at line 3 => `base + ((IsFridge ? 50 : 0) + cap / 5) * -1` (electricity cost scales with cap and fridge state).
+
+### `Window.SaveData` (per-container UI prefs)
+
+- Defined inside `Window` at `Plugins.UI/Window.cs:98-592`. Marked `[JsonObject(MemberSerialization.OptIn)]`.
+- Persisted fields: `int[20] ints` (window position, anchors, autodump enum, sharedType, ContainerFlag, columns, customAnchor, category mode, sortMode, color, priority, etc.), `HashSet<int> cats` (selected category IDs), `string filter` (text filter).
+- Hidden `BitArray32 b1` field is NOT `[JsonProperty]`, but rides along: `[OnSerializing]` at line 562 packs `b1.Bits` into `ints[0]`; `[OnDeserialized]` at line 568 unpacks it back. Newtonsoft.Json honors these `System.Runtime.Serialization` callbacks. Round-trip via `JsonConvert.SerializeObject`/`DeserializeObject<Window.SaveData>` is lossless for `b1`'s booleans (open, useBG, excludeDump, excludeCraft, alwaysSort, sort_ascending, etc.).
+- **`Card.GetWindowSaveData()`** at `Card.cs:2557-2569` - Returns `Window.dictData["LayerInventoryFloatMain0"]` if `IsPC`, `Window.dictData["ChestMerchant"]` if `trait is TraitChestMerchant`, else `c_windowSaveData` from `mapObj[2]`. So PC main-inventory and merchant-chest UI prefs live in a static `Window.dictData`, NOT on the Card. All other containers (chests, backpacks, bank, shipping, delivery, toolbelt) read from their own `c_windowSaveData`.
+- **Lazy-init**: `LayerInventory.CreateContainerPC` and `CreateContainer` (`LayerInventory.cs:455-478`, `:570-581`) lazy-create `c_windowSaveData` on first open if null. Special default: shipping chest gets `autodump = AutodumpFlag.none`. Pre-populated `c_windowSaveData` skips the lazy-init branch entirely.
+
+### Container Trait Taxonomy
+
+| Trait | Extends | `IsContainer` | `IsSpecialContainer` |
+|---|---|---|---|
+| `TraitBaseContainer` | `Trait` | `true` (override at line 71) | `false` |
+| `TraitContainer` | `TraitBaseContainer` | inherited | `false` |
+| `TraitMagicChest` | `TraitContainer` | inherited | `true` |
+| `TraitDeposit` (bank) | `TraitContainer` | inherited | `true` |
+| `TraitShippingChest` | `TraitContainer` | inherited | `true` |
+| `TraitDeliveryChest` | `TraitContainer` | inherited | `true` |
+| `TraitToolBelt` | `TraitContainer` | inherited | `false` |
+| `TraitChestMerchant` | `TraitContainer` | inherited | `false` |
+
+`Card.IsContainer => trait.IsContainer` (`Card.cs:2129`). `IsSpecialContainer` gates the rename UI (`UIInventory.cs:695` hides changeName button when `IsSpecialContainer && !IsMagicChest`), the wrench grid-extend, and a few auto-dump rules.
+
+### Wrench Upgrade Gating
+
+`TraitWrench.IsValidTarget(Thing t)` at `TraitWrench.cs:7-59` requires `t.IsInstalled` first (so equipped or carried containers are unreachable), then by wrench ID:
+
+- `storage` and `fridge`: target must be `TraitMagicChest`. `storage` adds 20 to `c_containerUpgrade.cap`. `fridge` sets `c_containerUpgrade.cool = 1` AND `t.elements.SetBase(405, 50)` (electricity element). `fridge` is one-shot (refuses to apply twice).
+- `extend_v` and `extend_h`: rejects `TraitMagicChest`, `TraitDeliveryChest`, and any `IsSpecialContainer`. Targets regular `TraitContainer` only. The upgrade is **single-shot per axis**: `Upgrade()` refuses unless `t.things.height == traitContainer.Height` (or `width == Width` for `extend_h`), so once `SetSize` grows the dimension by 1, a second wrench fails the equality gate.
+- `bed`: `TraitBed`; increments `c_containerSize` directly (debug mode adds 1000 for testing).
+- `tent_seabed`, `tent_soil`, `tent_elec`: target `TraitTent`; environment-checked.
+
+Implication: bank, shipping, delivery, and toolbelt cannot be wrench-modified through normal play. Bank is rejected by `IsSpecialContainer`. Shipping is rejected by `IsSpecialContainer`. Delivery is rejected explicitly AND by `IsSpecialContainer`. Toolbelt is equipped (not installed). Their `c_containerUpgrade` is always default-zero unless modded.
+
+### Singleton Containers
+
+`CardManager` holds three `Thing` singleton fields (`CardManager.cs:52-58`), spawned in `Game._Create` (`Game.cs:799-801`) before `Game.StartNewGame` runs:
+
+- **`container_shipping`** (id `"container_shipping"`, `TraitShippingChest`) - Outgoing daily-revenue chest. `GameDate.cs:282+` (`ShipGoods`) processes daily ship.
+- **`container_deliver`** (id `"container_delivery"` despite the field name; `TraitDeliveryChest`) - Incoming mail/orders. `GameDate.cs:418+` (`ShipPackages`) drains daily.
+- **`container_deposit`** (id `"container_deposit"`, `TraitDeposit`) - Bank vault for deposit money and items.
+
+Plus a per-character toolbelt:
+
+- **Toolbelt** - Reachable via `body.slots` filter; `id == "toolbelt"`, `TraitToolBelt`. Spawned with the character. Despite `IsSpecialContainer == false`, it cannot be wrench-extended because it is equipped (not installed) and `IsValidTarget` requires `IsInstalled`.
+
+Plus a per-faction-branch stash:
+
+- **`FactionBranch.stash`** (`FactionBranch.cs:85`) - `container_salary` Thing, created in `OnCreate(Zone)` per branch. Lives with the branch.
+
+Singletons whose Card is not respawned across runs need their `mapObj`/`mapStr` settings copied directly. They do not flow through normal Thing-export paths because the Card on the destination side already exists.
 
 ## Conditions & Curing
 

--- a/package.xml
+++ b/package.xml
@@ -5,7 +5,7 @@
   <author>nyaarium</author>
   <tags>General</tags>
   <loadPriority>100</loadPriority>
-  <version>1.3.2</version>
+  <version>1.3.3</version>
   <description>
     [h2]New Game++[/h2]
 
@@ -102,6 +102,12 @@
     [/list]
 
     [h2]Updates[/h2]
+
+    [b]2026.04.29[/b]
+
+    [list]
+    [*]Attempt fix of restore container properties.
+    [/list]
 
     [b]2026.03.24[/b]
 

--- a/src/Export/CharacterExporter.cs
+++ b/src/Export/CharacterExporter.cs
@@ -273,6 +273,54 @@ public static class CharacterExporter
 		return conditions;
 	}
 
+	public static ContainerSettingsData ExportToolbeltSettings(Chara c)
+	{
+		return ExtractSingletonContainerSettings(ItemSlotManager.GetToolbeltContainer(c));
+	}
+
+	public static ContainerSettingsData ExportBankSettings()
+	{
+		Card bank = (Card)EClass.game?.cards?.container_deposit;
+		return ExtractSingletonContainerSettings(bank);
+	}
+
+	public static ContainerSettingsData ExportShippingSettings()
+	{
+		Card shipping = (Card)EClass.game?.cards?.container_shipping;
+		return ExtractSingletonContainerSettings(shipping);
+	}
+
+	public static ContainerSettingsData ExportDeliverSettings()
+	{
+		Card deliver = (Card)EClass.game?.cards?.container_deliver;
+		return ExtractSingletonContainerSettings(deliver);
+	}
+
+	private static ContainerSettingsData ExtractSingletonContainerSettings(Card container)
+	{
+		if (container == null) return null;
+
+		var caps = ThingUtils.ExtractContainerSettings(container);
+		Dictionary<int, string> mapStr = null;
+		if (container.mapStr != null && container.mapStr.Count > 0)
+		{
+			mapStr = new Dictionary<int, string>(container.mapStr);
+		}
+
+		if (mapStr == null && !caps.cap.HasValue && !caps.cool.HasValue && string.IsNullOrEmpty(caps.windowJson))
+		{
+			return null;
+		}
+
+		return new ContainerSettingsData
+		{
+			mapStr = mapStr,
+			containerUpgradeCap = caps.cap,
+			containerUpgradeCool = caps.cool,
+			windowSaveDataJson = caps.windowJson
+		};
+	}
+
 	public static List<MutationData> ExportMutations(Chara c)
 	{
 		List<MutationData> mutations = new List<MutationData>();

--- a/src/Import/CharacterImporter.cs
+++ b/src/Import/CharacterImporter.cs
@@ -288,26 +288,71 @@ public static class CharacterImporter
 			ImportBodyParts(c, dumpData.charaBodyParts);
 		}
 
-		if (ModConfig.GetOption("includeBank")?.Value == true && dumpData.bankItems != null && dumpData.bankItems.Count > 0)
+		if (ModConfig.GetOption("includeBank")?.Value == true)
 		{
 			Card bankContainer = (Card)EClass.game.cards.container_deposit;
 			if (bankContainer != null && bankContainer.IsContainer)
 			{
-				foreach (ThingData bankItemData in dumpData.bankItems)
+				// Apply previously-exported bank settings (custom name, window prefs, upgrades) to the existing
+				// singleton bank container. Done independently of bankItems so a renamed/upgraded but empty bank
+				// still carries its settings.
+				if (dumpData.bankSettings != null)
 				{
-					try
+					ThingUtils.ApplyContainerSettings(
+						bankContainer,
+						dumpData.bankSettings.mapStr,
+						dumpData.bankSettings.containerUpgradeCap,
+						dumpData.bankSettings.containerUpgradeCool,
+						dumpData.bankSettings.windowSaveDataJson);
+				}
+
+				if (dumpData.bankItems != null && dumpData.bankItems.Count > 0)
+				{
+					foreach (ThingData bankItemData in dumpData.bankItems)
 					{
-						Card bankItem = ThingUtils.RestoreThingFromData(bankItemData);
-						if (bankItem != null)
+						try
 						{
-							StorageAuto.InsertToSubContainer(bankContainer, bankItem.Thing);
+							Card bankItem = ThingUtils.RestoreThingFromData(bankItemData);
+							if (bankItem != null)
+							{
+								StorageAuto.InsertToSubContainer(bankContainer, bankItem.Thing);
+							}
+						}
+						catch (System.Exception ex)
+						{
+							Msg.SayRaw($"NG+: Failed to import bank item '{bankItemData?.id ?? "unknown"}': {ex.Message}");
 						}
 					}
-					catch (System.Exception ex)
-					{
-						Msg.SayRaw($"NG+: Failed to import bank item '{bankItemData?.id ?? "unknown"}': {ex.Message}");
-					}
 				}
+			}
+		}
+
+		// Shipping and delivery chest settings ride independently of includeBank because they're
+		// home-faction logistics, not banking. The includeBank toggle's UI label promises only "money and
+		// items stored in the bank" - silently dropping shipping filter/sort under that toggle would surprise
+		// the user. Settings are also tiny so there's no item-cost reason to gate them.
+		if (EClass.game?.cards != null)
+		{
+			Card shippingContainer = (Card)EClass.game.cards.container_shipping;
+			if (shippingContainer != null && shippingContainer.IsContainer && dumpData.shippingSettings != null)
+			{
+				ThingUtils.ApplyContainerSettings(
+					shippingContainer,
+					dumpData.shippingSettings.mapStr,
+					dumpData.shippingSettings.containerUpgradeCap,
+					dumpData.shippingSettings.containerUpgradeCool,
+					dumpData.shippingSettings.windowSaveDataJson);
+			}
+
+			Card deliverContainer = (Card)EClass.game.cards.container_deliver;
+			if (deliverContainer != null && deliverContainer.IsContainer && dumpData.deliverSettings != null)
+			{
+				ThingUtils.ApplyContainerSettings(
+					deliverContainer,
+					dumpData.deliverSettings.mapStr,
+					dumpData.deliverSettings.containerUpgradeCap,
+					dumpData.deliverSettings.containerUpgradeCool,
+					dumpData.deliverSettings.windowSaveDataJson);
 			}
 		}
 
@@ -690,6 +735,19 @@ public static class CharacterImporter
 			if (toolbeltContainer != null)
 			{
 				toolbeltContainer.things.DestroyAll((Func<Thing, bool>)null);
+
+				// Apply previously-exported toolbelt settings (custom name, window prefs) to the existing toolbelt
+				// container. The toolbelt is a singleton - it isn't re-spawned, so settings must be poked into the
+				// already-existing card here.
+				if (dumpData.toolbeltSettings != null)
+				{
+					ThingUtils.ApplyContainerSettings(
+						toolbeltContainer,
+						dumpData.toolbeltSettings.mapStr,
+						dumpData.toolbeltSettings.containerUpgradeCap,
+						dumpData.toolbeltSettings.containerUpgradeCool,
+						dumpData.toolbeltSettings.windowSaveDataJson);
+				}
 			}
 		}
 

--- a/src/Models/DataModels.cs
+++ b/src/Models/DataModels.cs
@@ -27,7 +27,20 @@ public class ThingData
 	[DataMember] public int? slotIndex { get; set; }  // For multi-slot items (rings, hands) - distinguishes which slot
 	[DataMember] public int[] ints { get; set; }  // Full _ints array (contains type, use count, and other item-specific data)
 	[DataMember] public Dictionary<int, int> mapInt { get; set; }  // mapInt dictionary (contains c_dyeMat[3], c_charges[7], c_ammo[27], etc.)
+	[DataMember] public Dictionary<int, string> mapStr { get; set; }  // mapStr dictionary (c_altName=1, c_extraNameRef=12, c_idTalk, c_idDeity, etc.)
 	[DataMember] public List<int> sockets { get; set; }  // Ranged weapon mod sockets: count = list length; 0 = empty, else elementId*1000+encLv
+	[DataMember] public int? containerUpgradeCap { get; set; }  // mapObj[12].cap - storage wrench capacity bonus on Magic Chests
+	[DataMember] public int? containerUpgradeCool { get; set; }  // mapObj[12].cool - fridge wrench cooling flag
+	[DataMember] public string windowSaveDataJson { get; set; }  // mapObj[2] - per-container UI prefs (filter, cats, sortMode, autodump, sharedType) round-tripped via Newtonsoft
+}
+
+[DataContract]
+public class ContainerSettingsData
+{
+	[DataMember] public Dictionary<int, string> mapStr { get; set; }
+	[DataMember] public int? containerUpgradeCap { get; set; }
+	[DataMember] public int? containerUpgradeCool { get; set; }
+	[DataMember] public string windowSaveDataJson { get; set; }
 }
 
 [DataContract]
@@ -151,4 +164,8 @@ public class CharacterDumpData
 	[DataMember] public List<ContainerItemData> containerContents { get; set; }
 	[DataMember] public List<ThingData> bankItems { get; set; }  // Items in bank container (including money & items)
 	[DataMember] public CharaGenesData charaGenes { get; set; }
+	[DataMember] public ContainerSettingsData toolbeltSettings { get; set; }  // Toolbelt container's mapStr/mapObj (toolbelt isn't in wornEquipment, so settings need their own slot)
+	[DataMember] public ContainerSettingsData bankSettings { get; set; }      // Bank (deposit) container's mapStr/mapObj (bank is also a singleton; only its contents went through the existing path)
+	[DataMember] public ContainerSettingsData shippingSettings { get; set; }  // Shipping chest (CardManager.container_shipping) singleton settings
+	[DataMember] public ContainerSettingsData deliverSettings { get; set; }   // Delivery chest (CardManager.container_deliver) singleton settings
 }

--- a/src/NewGamePlus.cs
+++ b/src/NewGamePlus.cs
@@ -8,7 +8,7 @@ using HarmonyLib;
 namespace NewGamePlus;
 
 [BepInDependency("evilmask.elinplugins.modoptions", BepInEx.BepInDependency.DependencyFlags.SoftDependency)]
-[BepInPlugin("nyaarium.newgameplusplus", "New Game++", "1.3.2")]
+[BepInPlugin("nyaarium.newgameplusplus", "New Game++", "1.3.3")]
 public class NewGamePlus : BaseUnityPlugin
 {
 	private static NewGamePlus instance;
@@ -91,7 +91,11 @@ public class NewGamePlus : BaseUnityPlugin
 			wornEquipment = itemResult.wornEquipment,
 			containerContents = itemResult.containerContents,
 			bankItems = CharacterExporter.ExportBankItems(),
-			charaGenes = ExportGenes(c)
+			charaGenes = ExportGenes(c),
+			toolbeltSettings = CharacterExporter.ExportToolbeltSettings(c),
+			bankSettings = CharacterExporter.ExportBankSettings(),
+			shippingSettings = CharacterExporter.ExportShippingSettings(),
+			deliverSettings = CharacterExporter.ExportDeliverSettings()
 		};
 
 		string dumpFilePath = GetDumpFilePath();

--- a/src/Utils/ThingUtils.cs
+++ b/src/Utils/ThingUtils.cs
@@ -62,6 +62,16 @@ public static class ThingUtils
 			socketsList = new List<int>(cardThing.sockets);
 		}
 
+		// Export mapStr passthrough (c_altName, c_extraNameRef, c_idTalk, etc.)
+		Dictionary<int, string> mapStrDict = null;
+		if (cardThing.mapStr != null && cardThing.mapStr.Count > 0)
+		{
+			mapStrDict = new Dictionary<int, string>(cardThing.mapStr);
+		}
+
+		// Container settings/upgrades from mapObj. Read via TryGetValue to avoid triggering lazy-create on every Thing.
+		var containerCaps = ExtractContainerSettings(cardThing);
+
 		return new ThingData
 		{
 			id = ((Card)thing).id,
@@ -74,8 +84,78 @@ public static class ThingUtils
 			containerUid = containerUid,
 			ints = intsArray,
 			mapInt = mapIntDict,
-			sockets = socketsList
+			mapStr = mapStrDict,
+			sockets = socketsList,
+			containerUpgradeCap = containerCaps.cap,
+			containerUpgradeCool = containerCaps.cool,
+			windowSaveDataJson = containerCaps.windowJson
 		};
+	}
+
+	internal static (int? cap, int? cool, string windowJson) ExtractContainerSettings(Card card)
+	{
+		int? cap = null;
+		int? cool = null;
+		string windowJson = null;
+		if (card?.mapObj != null)
+		{
+			if (card.mapObj.TryGetValue(COBJ.containerUpgrade, out object upgObj) && upgObj is ContainerUpgrade cu)
+			{
+				cap = cu.cap;
+				cool = cu.cool;
+			}
+			if (card.mapObj.TryGetValue(COBJ.windowSaveData, out object wsObj) && wsObj is Window.SaveData ws)
+			{
+				try
+				{
+					windowJson = Newtonsoft.Json.JsonConvert.SerializeObject(ws);
+				}
+				catch (Exception ex)
+				{
+					DebugLogger.DebugLog("ThingUtils.cs:ExtractContainerSettings", "Failed to serialize Window.SaveData", null, new Dictionary<string, object> { { "id", card.id }, { "error", ex.Message } });
+				}
+			}
+		}
+		return (cap, cool, windowJson);
+	}
+
+	internal static void ApplyContainerSettings(Card card, Dictionary<int, string> mapStr, int? upgradeCap, int? upgradeCool, string windowJson)
+	{
+		if (card == null) return;
+
+		if (mapStr != null && mapStr.Count > 0)
+		{
+			if (card.mapStr == null) card.mapStr = new Dictionary<int, string>();
+			foreach (var kvp in mapStr) card.mapStr[kvp.Key] = kvp.Value;
+		}
+
+		if (upgradeCap.HasValue || upgradeCool.HasValue)
+		{
+			if (card.mapObj == null) card.mapObj = new Dictionary<int, object>();
+			ContainerUpgrade cu = new ContainerUpgrade
+			{
+				cap = upgradeCap ?? 0,
+				cool = upgradeCool ?? 0
+			};
+			card.mapObj[COBJ.containerUpgrade] = cu;
+		}
+
+		if (!string.IsNullOrEmpty(windowJson))
+		{
+			try
+			{
+				Window.SaveData ws = Newtonsoft.Json.JsonConvert.DeserializeObject<Window.SaveData>(windowJson);
+				if (ws != null)
+				{
+					if (card.mapObj == null) card.mapObj = new Dictionary<int, object>();
+					card.mapObj[COBJ.windowSaveData] = ws;
+				}
+			}
+			catch (Exception ex)
+			{
+				DebugLogger.DebugLog("ThingUtils.cs:ApplyContainerSettings", "Failed to deserialize Window.SaveData; defaults will apply", null, new Dictionary<string, object> { { "id", card.id }, { "error", ex.Message } });
+			}
+		}
 	}
 
 	/// <summary>
@@ -182,6 +262,18 @@ public static class ThingUtils
 			{
 				card.mapInt[kvp.Key] = kvp.Value;
 			}
+		}
+
+		// Restore mapStr + container settings/upgrades (mapObj). Order matters less than ensuring this happens
+		// before any code path observes the container's c_* properties, which lazy-create defaults.
+		ApplyContainerSettings(card, thingData.mapStr, thingData.containerUpgradeCap, thingData.containerUpgradeCool, thingData.windowSaveDataJson);
+
+		// ThingGen.Create called things.SetOwner(this) before mapInt was restored, caching width/height from a default
+		// c_containerSize. Re-run SetOwner so wrench-extended containers (extend_v / extend_h) pick up the saved grid.
+		// Mirrors the Duplicate-path idiom at disassembly Card.cs:3555-3565.
+		if (card.IsContainer && card.c_containerSize != 0)
+		{
+			card.things.SetOwner(card);
 		}
 
 		// Restore mod sockets for ranged weapons so slot count and embedded attachments are preserved


### PR DESCRIPTION
Trying a patch for #18. 

- ThingData export was dropping `mapObj` and `mapStr` on every container Thing, so Magic Chest cap/fridge upgrades, per-container window prefs (filter, cats, sortMode, autodump, sharedType), and custom names were silently lost across NG+. Fixed by adding `mapStr`/`containerUpgradeCap`/`containerUpgradeCool`/`windowSaveDataJson` fields to `ThingData`, with `Window.SaveData` round-tripped via `Newtonsoft.Json` (game-provided DLL referenced with `Private="False"`).
- Bank, shipping, and delivery chests are per-game singletons whose Card isn't re-spawned by NG+, so their `mapObj`/`mapStr` settings can't ride a normal `RestoreThingFromData` path. Added `toolbeltSettings`, `bankSettings`, `shippingSettings`, `deliverSettings` slots on `CharacterDumpData` and apply them directly to the existing singleton cards. Bank settings stay gated on `includeBank` (rides with bank items, `c_altName` is user-authored content). Shipping/delivery settings are unconditional since there's no items pathway to gate against.
- Wrench-extended (`extend_v`/`extend_h`) backpacks were collapsing to the default 8x5 grid because `ThingGen.Create` calls `ThingContainer.SetOwner` once with empty `mapInt`, then nothing re-runs it after `c_containerSize` is restored. Added a `card.things.SetOwner(card)` re-call after `mapInt` restore in `RestoreThingFromData`, gated on `card.IsContainer && card.c_containerSize != 0`. Mirrors the `Card.Duplicate` idiom in the base game.

─ Claude